### PR TITLE
Add raw README url to yaml config

### DIFF
--- a/yaml/gr-air-modes.md
+++ b/yaml/gr-air-modes.md
@@ -17,6 +17,7 @@ stable_release: master
 title: gr-air-modes
 type: application
 website: https://github.com/bistromath/gr-air-modes
+readmeraw: https://raw.githubusercontent.com/bistromath/gr-air-modes/master/README
 --- 
 
 gr-air-modes implements a software-defined radio receiver for Mode S

--- a/yaml/gr-ais.md
+++ b/yaml/gr-ais.md
@@ -14,5 +14,6 @@ stable_release: master
 title: gr-ais
 type: application
 website: https://github.com/bistromath/gr-ais
+readmeraw: Nil as of now
 --- 
 

--- a/yaml/gr-benchmark.md
+++ b/yaml/gr-benchmark.md
@@ -14,6 +14,7 @@ stable_release: master
 title: gr-benchmark
 type: application
 website: http://stats.gnuradio.org
+readmeraw: https://raw.githubusercontent.com/osh/gr-benchmark/master/README
 --- 
 
 # Running the benchmark

--- a/yaml/gr-bluetooth.md
+++ b/yaml/gr-bluetooth.md
@@ -16,6 +16,7 @@ stable_release: master
 title: gr-bluetooth
 type: application
 website: http://gr-bluetooth.sourceforge.net/
+readmeraw: https://raw.githubusercontent.com/greatscottgadgets/gr-bluetooth/master/README.md
 --- 
 
 An implementation of the Bluetooth baseband layer for GNU Radio for

--- a/yaml/gr-drm.md
+++ b/yaml/gr-drm.md
@@ -18,6 +18,7 @@ stable_release: master
 title: gr-drm
 type: application
 website: https://github.com/kit-cel/gr-drm
+readmeraw: https://raw.githubusercontent.com/kit-cel/gr-drm/master/README.md
 --- 
 
 This project features a DRM/DRM+ software transmitter fully integrated into GNU

--- a/yaml/gr-dsd.md
+++ b/yaml/gr-dsd.md
@@ -14,6 +14,7 @@ stable_release: master
 title: gr-dsd
 type: blocks
 website: https://github.com/argilo/gr-dsd
+readmeraw: https://raw.githubusercontent.com/argilo/gr-dsd/master/README 
 --- 
 The block expects 48000 samples per second input, and outputs sound at
 8000 samples per second.  The input should be FM-demodulated (for

--- a/yaml/gr-dvbs2.md
+++ b/yaml/gr-dvbs2.md
@@ -14,6 +14,7 @@ stable_release: master
 title: gr-dvbs2
 type: application
 website: https://github.com/drmpeg/gr-dvbs2
+readmeraw: https://raw.githubusercontent.com/drmpeg/gr-dvbs2/master/README
 --- 
 
 The goal of this project is to build a software-defined DVB-S2


### PR DESCRIPTION
The URL to raw README file can be helpful in fetching OOT Module page content. For now, all the URLs are Github based. Same applies for repos hosted other than Github also.
